### PR TITLE
fix!: Remove field name (was not used by code in this library)

### DIFF
--- a/packages/react-properties-selector/README.md
+++ b/packages/react-properties-selector/README.md
@@ -74,7 +74,6 @@ The library is compiled to ES5 and no polyfills are required.
 
 ```ts
 <AmountPropertySelector
-  fieldName="..."
   propertyName="..."
   propertyValueSet={...}
   inputUnit={...}

--- a/packages/react-properties-selector/src/__stories__/amount-property-selector/example-1.stories.tsx
+++ b/packages/react-properties-selector/src/__stories__/amount-property-selector/example-1.stories.tsx
@@ -43,7 +43,6 @@ export function Example1(): React.ReactElement<{}> {
       <div>PropertyValueSet: {PropertyValueSet.toString(state.propertyValueSet)}</div>
       <div>
         <AmountPropertySelector
-          fieldName="a"
           propertyName="a"
           propertyValueSet={state.propertyValueSet}
           inputUnit={state.selectedUnit}

--- a/packages/react-properties-selector/src/amount/amount-property-selector.tsx
+++ b/packages/react-properties-selector/src/amount/amount-property-selector.tsx
@@ -26,7 +26,6 @@ export interface AmountPropertySelectorProps {
   readonly onFormatSelectorToggled?: OnFormatSelectorToggled;
   readonly onValueChange: (newValue: PropertyValue.PropertyValue | undefined) => void;
   readonly debounceTime?: number;
-  readonly fieldName: string;
   readonly unitsFormat: {
     readonly [key: string]: UnitFormat.UnitFormat;
   };

--- a/packages/react-properties-selector/src/properties-selector/default-property-selector-component.tsx
+++ b/packages/react-properties-selector/src/properties-selector/default-property-selector-component.tsx
@@ -28,7 +28,6 @@ const RadioGroupPropertySelectorDefault = createRadioGroupPropertySelector({});
 
 export interface PropertySelectorProps {
   readonly selectorType: PropertySelectorType;
-  readonly fieldName: string;
   readonly propertyName: string;
   readonly quantity: string;
   readonly validationFilter: PropertyFilter.PropertyFilter;
@@ -76,7 +75,6 @@ export function createPropertySelector({
 }: CreatePropertySelectorProps): PropertySelector {
   return function PropertySelector({
     selectorType,
-    fieldName,
     propertyName,
     quantity,
     validationFilter,
@@ -213,7 +211,6 @@ export function createPropertySelector({
             onFormatSelectorToggled={(active: boolean) => onPropertyFormatSelectorToggled(propertyName, active)}
             onValueChange={onValueChange}
             notNumericMessage={translateValueMustBeNumericMessage()}
-            fieldName={fieldName}
             // If it is optional then use blank required message
             isRequiredMessage={
               optionalProperties && optionalProperties.indexOf(propertyName) !== -1

--- a/packages/react-properties-selector/src/properties-selector/properties-selector.tsx
+++ b/packages/react-properties-selector/src/properties-selector/properties-selector.tsx
@@ -289,7 +289,6 @@ function createPropertySelectorRenderInfos(
 
       const propertySelectorComponentProps: PropertySelectorProps = {
         selectorType: selectorType,
-        fieldName: property.field_name || property.name,
         propertyName: property.name,
         quantity: property.quantity,
         validationFilter: property.validation_filter,

--- a/packages/react-property-selectors/CHANGELOG.md
+++ b/packages/react-property-selectors/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased](https://github.com/promaster-sdk/property/compare/@promaster-sdk%2Freact-property-selectors@9.1.0...master)
 
+## Changed
+
+- Removed `fieldName` prop, see PR [#39](https://github.com/promaster-sdk/property/pull/39).
+
 ## [v9.1.0](https://github.com/promaster-sdk/property/compare/@promaster-sdk%2Freact-property-selectors@9.0.0...9.1.0)
 
 ## Added

--- a/packages/react-property-selectors/README.md
+++ b/packages/react-property-selectors/README.md
@@ -101,7 +101,6 @@ const sel = useAmountFormatSelector({
 
 ```ts
 const sel = useAmountPropertySelector({
-  fieldName: "a",
   propertyName: "a",
   propertyValueSet: state.propertyValueSet,
   inputUnit: state.selectedUnit,

--- a/packages/react-property-selectors/src/__stories__/amount-property-selector/example-1-hooks.stories.tsx
+++ b/packages/react-property-selectors/src/__stories__/amount-property-selector/example-1-hooks.stories.tsx
@@ -58,7 +58,6 @@ export function Example1(): React.ReactElement<{}> {
   );
 
   const selOptions = {
-    fieldName: "a",
     propertyName: "a",
     propertyValueSet: state.propertyValueSet,
     inputUnit: state.selectedUnit,

--- a/packages/react-property-selectors/src/__stories__/selector-ui/example-product-properties.tsx
+++ b/packages/react-property-selectors/src/__stories__/selector-ui/example-product-properties.tsx
@@ -16,7 +16,6 @@ export type MyItem = {
 export type MyPropertyInfo = {
   readonly selectorType?: "Checkbox" | "RadioGroup";
   readonly sortNo: number;
-  readonly fieldName?: string;
   readonly name: string;
   readonly group: string;
   readonly quantity: string;

--- a/packages/react-property-selectors/src/amount/use-amount-property-selector.tsx
+++ b/packages/react-property-selectors/src/amount/use-amount-property-selector.tsx
@@ -24,7 +24,6 @@ export type UseAmountPropertySelectorOptions = {
   readonly onFormatCleared: UseAmountFormatSelectorOnFormatCleared;
   readonly onValueChange: (newValue: PropertyValue.PropertyValue | undefined) => void;
   readonly debounceTime?: number;
-  readonly fieldName: string;
   readonly unitsFormat: UnitFormat.UnitFormatMap;
   readonly units: UnitMap.UnitMap;
   readonly comparer?: PropertyValue.Comparer;

--- a/packages/react-property-selectors/src/properties-selector/use-properties-selector.tsx
+++ b/packages/react-property-selectors/src/properties-selector/use-properties-selector.tsx
@@ -57,6 +57,7 @@ export type UsePropertiesSelectorOptions<TItem, TProperty> = {
   readonly readOnlyProperties?: ReadonlyArray<string>;
   // Specifies property names of properties that should be optional (only for amounts for now)
   readonly optionalProperties?: ReadonlyArray<string>;
+
   // Specifies input format per property name for entering amount properties (measure unit and decimal count)
   readonly propertyFormats?: PropertyFormats;
 
@@ -82,7 +83,6 @@ export type UsePropertiesSelectorOptions<TItem, TProperty> = {
 };
 
 export type PropertyInfo = {
-  readonly fieldName?: string;
   readonly name: string;
   readonly group: string;
   readonly quantity: string;
@@ -285,7 +285,6 @@ function createSelectorHookInfo<TItem, TProperty>(
           onFormatCleared: () => onPropertyFormatCleared(propertyName),
           onValueChange,
           notNumericMessage: valueMustBeNumericMessage,
-          fieldName: propertyInfo.fieldName || propertyInfo.name,
           // If it is optional then use blank required message
           isRequiredMessage:
             optionalProperties && optionalProperties.indexOf(propertyName) !== -1 ? "" : valueIsRequiredMessage,


### PR DESCRIPTION
BREAKING CHANGE: This will remove `fieldName` property from all objects. It was not used by the library in any place. If your application needs this field it should be able to keep track of it itself now.