### PR TITLE
fix(properties-selector)!: Property format function

### DIFF
--- a/packages/react-property-selectors/CHANGELOG.md
+++ b/packages/react-property-selectors/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Changed
 
+- Change the API of the properties-selector so that instead of sending a dictionary of property formats, you send in a callback that will provide the format for a property, see PR [#40](https://github.com/promaster-sdk/property/pull/40).
 - Removed `fieldName` prop, see PR [#39](https://github.com/promaster-sdk/property/pull/39).
 
 ## [v9.1.0](https://github.com/promaster-sdk/property/compare/@promaster-sdk%2Freact-property-selectors@9.0.0...9.1.0)

--- a/packages/react-property-selectors/src/__stories__/properties-selector/example-1.stories.tsx
+++ b/packages/react-property-selectors/src/__stories__/properties-selector/example-1.stories.tsx
@@ -21,7 +21,7 @@ export function Example1(): React.ReactElement<{}> {
     units,
     unitsFormat,
     unitLookup,
-    propertyFormats,
+    getPropertyFormat: (propertyName) => propertyFormats[propertyName],
     onPropertyFormatChanged: (propertyName, unit, decimalCount) =>
       setPropertyFormats({ ...propertyFormats, [propertyName]: { unit, decimalCount } }),
     properties: propInfo.properties,

--- a/packages/react-property-selectors/src/properties-selector/use-properties-selector.tsx
+++ b/packages/react-property-selectors/src/properties-selector/use-properties-selector.tsx
@@ -59,13 +59,7 @@ export type UsePropertiesSelectorOptions<TItem, TProperty> = {
   readonly optionalProperties?: ReadonlyArray<string>;
 
   // Specifies input format per property name for entering amount properties (measure unit and decimal count)
-  readonly propertyFormats?: PropertyFormats;
-
-  // Debounce value for inputs in ms. Defaults to 350.
-  readonly inputDebounceTime?: number;
-
-  // Group handling
-  readonly initiallyClosedGroups?: ReadonlyArray<string>;
+  readonly getPropertyFormat?: (propertyName: string) => UsePropertiesSelectorAmountFormat | undefined;
 
   // Use customUnits
   readonly unitsFormat: {
@@ -73,6 +67,12 @@ export type UsePropertiesSelectorOptions<TItem, TProperty> = {
   };
   readonly units: UnitMap.UnitMap;
   readonly unitLookup: UnitMap.UnitLookup;
+
+  // Debounce value for inputs in ms. Defaults to 350.
+  readonly inputDebounceTime?: number;
+
+  // Group handling
+  readonly initiallyClosedGroups?: ReadonlyArray<string>;
 
   // Comparer
   readonly valueComparer?: PropertyValue.Comparer;
@@ -189,7 +189,7 @@ function createSelectorHookInfo<TItem, TProperty>(
 ): PropertySelectorHookInfo<TItem> {
   const {
     selectedProperties,
-    propertyFormats,
+    getPropertyFormat,
     valueComparer,
     properties,
     autoSelectSingleValidValue,
@@ -222,7 +222,7 @@ function createSelectorHookInfo<TItem, TProperty>(
 
   // TODO: Better handling of format to use when the format is missing in the map
   const defaultFormat = getDefaultFormat(propertyInfo, selectedItemValue);
-  const propertyFormat = propertyFormats[propertyInfo.name] || defaultFormat;
+  const propertyFormat = getPropertyFormat(propertyInfo.name) || defaultFormat;
 
   const readOnly = readOnlyProperties.indexOf(propertyInfo.name) !== -1;
   const propertyOnChange = handleChange(
@@ -553,7 +553,7 @@ function optionsWithDefaults<TItem, TPropety>(
 
     readOnlyProperties: options.readOnlyProperties || [],
     optionalProperties: options.optionalProperties || [],
-    propertyFormats: options.propertyFormats || {},
+    getPropertyFormat: options.getPropertyFormat || (() => undefined),
 
     inputDebounceTime: options.inputDebounceTime || 350,
 

--- a/packages/react-property-selectors/src/properties-selector/use-properties-selector.tsx
+++ b/packages/react-property-selectors/src/properties-selector/use-properties-selector.tsx
@@ -20,20 +20,65 @@ export type UsePropertiesSelectorAmountFormat = {
 export type PropertyFormats = { readonly [key: string]: UsePropertiesSelectorAmountFormat };
 
 export type UsePropertiesSelectorOptions<TItem, TProperty> = {
-  // Required inputs
+  /**
+   * An array of objects representing the properties that should be selectable. The type of the objects can be
+   * anything the application wants, so the application also needs to provide several functions
+   * to extract information from these objects that the selector needs.
+   */
   readonly properties: ReadonlyArray<TProperty>;
+
+  /**
+   * From a property object, extract information needed by the selector.
+   */
   readonly getPropertyInfo: GetPropertyInfo<TProperty>;
+
+  /**
+   * From a property object, extract items (applies to discrete properties only).
+   */
   readonly getPropertyItems: GetPropertyItems<TItem, TProperty>;
 
+  /**
+   * From an item object, extract the property value.
+   */
+  readonly getItemValue: GetItemValue<TItem>;
+
+  /**
+   * From an item, get the property filter. The items can be any object the application wants, so therefore the
+   * application must provide this function to extract the property value from the item.
+   */
+  readonly getItemFilter: GetItemFilter<TItem>;
+
+  /**
+   * Get an item that corresponds to a property value of undefined. This item will be shown
+   * in eg. a dropdown when the value of the property is undefiend.
+   */
+  readonly getUndefinedValueItem: () => TItem;
+
+  /**
+   * The currently selected properties in the selector.
+   */
   readonly selectedProperties: PropertyValueSet.PropertyValueSet;
+
+  /**
+   * Will be called when selected properties changes.
+   */
+  readonly onChange?: OnPropertiesChanged;
+
+  /**
+   * Will be called when the user selects a different format (unit, decimals) for an amount property.
+   */
+  readonly onPropertyFormatChanged?: (propertyName: string, unit: Unit.Unit<unknown>, decimalCount: number) => void;
+
+  /**
+   * Will be called when the user wants to reset the format of a property to the default.
+   */
+  readonly onPropertyFormatCleared?: (propertyName: string) => void;
 
   // Used to print error messages
   readonly filterPrettyPrint?: PropertyFiltering.FilterPrettyPrint;
-
-  // Get an item that corresponds to a property value of undefined
-  readonly getUndefinedValueItem: () => TItem;
-  readonly getItemValue: GetItemValue<TItem>;
-  readonly getItemFilter: GetItemFilter<TItem>;
+  // Translations
+  readonly valueMustBeNumericMessage?: string;
+  readonly valueIsRequiredMessage?: string;
 
   // Includes the raw property name and value in paranthesis
   readonly showCodes?: boolean;
@@ -43,15 +88,6 @@ export type UsePropertiesSelectorOptions<TItem, TProperty> = {
   readonly autoSelectSingleValidValue?: boolean;
   // Locks fields with single valid value
   readonly lockSingleValidValue?: boolean;
-
-  // Events
-  readonly onChange?: OnPropertiesChanged;
-  readonly onPropertyFormatChanged?: (propertyName: string, unit: Unit.Unit<unknown>, decimalCount: number) => void;
-  readonly onPropertyFormatCleared?: (propertyName: string) => void;
-
-  // Translations
-  readonly valueMustBeNumericMessage?: string;
-  readonly valueIsRequiredMessage?: string;
 
   // Specifies property names of properties that should be read-only
   readonly readOnlyProperties?: ReadonlyArray<string>;


### PR DESCRIPTION
BREAKING CHANGE: This PR will change the API of the properties-selector so that instead of sending a dictionary of property formats, you send in a callback that will provide the format for a property.