### PR TITLE
feat(properties-selector)!: Move readonly and optional to PropertyInfo

### DIFF
--- a/packages/react-property-selectors/CHANGELOG.md
+++ b/packages/react-property-selectors/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Changed
 
+- Remove readonly and optional arrays of property names and instead include boolean properties on the PropertyInfo object for isReadonly and isOptional, see PR [#41](https://github.com/promaster-sdk/property/pull/41).
 - Change the API of the properties-selector so that instead of sending a dictionary of property formats, you send in a callback that will provide the format for a property, see PR [#40](https://github.com/promaster-sdk/property/pull/40).
 - Removed `fieldName` prop, see PR [#39](https://github.com/promaster-sdk/property/pull/39).
 

--- a/packages/react-property-selectors/src/properties-selector/use-properties-selector.tsx
+++ b/packages/react-property-selectors/src/properties-selector/use-properties-selector.tsx
@@ -79,11 +79,6 @@ export type UsePropertiesSelectorOptions<TItem, TProperty> = {
    */
   readonly getPropertyFormat?: (propertyName: string) => UsePropertiesSelectorAmountFormat | undefined;
 
-  // // Specifies property names of properties that should be read-only
-  // readonly readOnlyProperties?: ReadonlyArray<string>;
-  // // Specifies property names of properties that should be optional (only for amounts for now)
-  // readonly optionalProperties?: ReadonlyArray<string>;
-
   // Used to print error messages
   readonly filterPrettyPrint?: PropertyFiltering.FilterPrettyPrint;
   // Translations
@@ -262,7 +257,6 @@ function createSelectorHookInfo<TItem, TProperty>(
   const defaultFormat = getDefaultFormat(propertyInfo, selectedItemValue);
   const propertyFormat = getPropertyFormat(propertyInfo.name) || defaultFormat;
 
-  // const readOnly = readOnlyProperties.indexOf(propertyInfo.name) !== -1;
   const readOnly = !!propertyInfo.isReadonly;
   const propertyOnChange = handleChange(
     onChange,


### PR DESCRIPTION
BREAKING CHANGE: Remove readonly and optional arrays of property names and instead include boolean properties on the PropertyInfo object for isReadonly and isOptional.