### PR TITLE
feat(property-selectors)!: Expose useDiscretePropertySelector setIsOpen

### DIFF
--- a/packages/react-property-selectors/src/__stories__/properties-selector/example-2.stories.tsx
+++ b/packages/react-property-selectors/src/__stories__/properties-selector/example-2.stories.tsx
@@ -171,6 +171,14 @@ export function Example2(): React.ReactElement<{}> {
               </Fragment>
             );
           })}
+          {sel.getGroupProperties(group).map((property) => {
+            const selectorInfo = sel.getPropertySelectorHookInfo(property);
+            return (
+              <Fragment key={property.name}>
+                {selectorInfo.type === "Discrete" && <CustomDropdown options={selectorInfo.getUseDiscreteOptions()} />}
+              </Fragment>
+            );
+          })}
         </Fragment>
       ))}
     </div>
@@ -204,6 +212,32 @@ function Select({
           </option>
         ))}
       </select>
+    </div>
+  );
+}
+
+function CustomDropdown({
+  options,
+}: {
+  readonly options: DiscretePropertySelectorOptions<PropertyValueDef>;
+}): JSX.Element {
+  const discreteSelector = useDiscretePropertySelector(options);
+  return (
+    <div style={{ display: "flex", gap: "15px", alignItems: "center" }}>
+      <button {...discreteSelector.getDropdownToggleButtonProps()}>
+        <span>{discreteSelector.getItemLabel(discreteSelector.selectedItem.text, discreteSelector.selectedItem)}</span>
+        <i className="fa fa-caret-down" />
+      </button>
+      {discreteSelector.isOpen && (
+        <ul>
+          {discreteSelector.items.map((item) => (
+            <li key={item.sortNo} {...discreteSelector.getDropdownListItemProps(item)}>
+              <span>{discreteSelector.getItemLabel(item.text, item)}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+      <button onClick={() => discreteSelector.setIsOpen(!discreteSelector.isOpen)}>Toggle</button>
     </div>
   );
 }

--- a/packages/react-property-selectors/src/__tests__/properties-selector/discrete-select-test-component.tsx
+++ b/packages/react-property-selectors/src/__tests__/properties-selector/discrete-select-test-component.tsx
@@ -151,6 +151,16 @@ export function DiscreteSelectTestComponent({
               </Fragment>
             );
           })}
+          {sel.getGroupProperties(group).map((property) => {
+            const selectorInfo = sel.getPropertySelectorHookInfo(property);
+            return (
+              <Fragment key={property.name}>
+                {selectorInfo.type === "Discrete" && (
+                  <CustomDropdown propertyName={property.name} options={selectorInfo.getUseDiscreteOptions()} />
+                )}
+              </Fragment>
+            );
+          })}
         </Fragment>
       ))}
     </>
@@ -173,5 +183,27 @@ export function Select({
         </option>
       ))}
     </select>
+  );
+}
+
+function CustomDropdown({
+  options,
+  propertyName,
+}: {
+  readonly options: DiscretePropertySelectorOptions<PropertyValueDef>;
+  readonly propertyName: string;
+}): JSX.Element {
+  const discreteSelector = useDiscretePropertySelector(options);
+  return (
+    <>
+      <button {...discreteSelector.getDropdownToggleButtonProps()} />
+      {discreteSelector.isOpen && <div>{`content-${propertyName}`}</div>}
+      <button
+        data-testid={`button-${propertyName}`}
+        onClick={() => discreteSelector.setIsOpen(!discreteSelector.isOpen)}
+      >
+        Toggle
+      </button>
+    </>
   );
 }

--- a/packages/react-property-selectors/src/__tests__/properties-selector/discrete-select.test.tsx
+++ b/packages/react-property-selectors/src/__tests__/properties-selector/discrete-select.test.tsx
@@ -110,4 +110,21 @@ describe("Test <DiscreteSelectTestComponent />", () => {
     expect(optionA1.selected).toBeFalsy();
     expect(optionA2.selected).toBeTruthy();
   });
+
+  it("Select should toggle when pressing a button with setIsOpen(!setIsOpen) once", async () => {
+    render(<DiscreteSelectTestComponent />);
+    const selectA = screen.getByTestId("button-select_a") as HTMLButtonElement;
+    fireEvent.click(selectA);
+    const contentA = screen.queryByText("content-select_a") as HTMLDivElement;
+    expect(contentA).toBeTruthy();
+  });
+
+  it("Select should toggle twice when pressing a button with setIsOpen(!setIsOpen) twice", async () => {
+    render(<DiscreteSelectTestComponent />);
+    const selectA = screen.getByTestId("button-select_a") as HTMLButtonElement;
+    fireEvent.click(selectA);
+    fireEvent.click(selectA);
+    const contentA = screen.queryByText("content-select_a") as HTMLDivElement;
+    expect(contentA).toBeNull();
+  });
 });

--- a/packages/react-property-selectors/src/discrete/use-discrete-property-selector.tsx
+++ b/packages/react-property-selectors/src/discrete/use-discrete-property-selector.tsx
@@ -56,6 +56,7 @@ export type DiscretePropertySelector<TItem> = {
   readonly getDropdownListItemProps: (item: TItem) => React.LiHTMLAttributes<HTMLLIElement>;
   readonly getRadioItemProps: (item: TItem) => React.HTMLAttributes<HTMLDivElement>;
   readonly getCheckboxDivProps: () => React.HTMLAttributes<HTMLDivElement>;
+  readonly setIsOpen: (toggle: boolean) => void;
 };
 
 export function useDiscretePropertySelector<TItem>(
@@ -159,8 +160,10 @@ export function useDiscretePropertySelector<TItem>(
     getCheckboxDivProps: () => ({
       onClick: () => onValueChange(isTrueItem ? getItemValue(falseItem)!! : getItemValue(trueItem)!!),
     }),
-
     items: selectableItems,
+    setIsOpen: (toggle) => {
+      setIsOpen(toggle);
+    },
   };
 }
 

--- a/packages/react-property-selectors/src/discrete/use-discrete-property-selector.tsx
+++ b/packages/react-property-selectors/src/discrete/use-discrete-property-selector.tsx
@@ -49,6 +49,7 @@ export type DiscretePropertySelector<TItem> = {
   readonly getItemToolTip: (item: TItem) => string;
   readonly getItemValue: (item: TItem) => string;
   readonly isItemValid: (item: TItem) => boolean;
+  readonly setIsOpen: (toggle: boolean) => void;
   // Tag-specific props
   readonly getSelectProps: () => DiscretePropertySelectorSelectProps; //React.SelectHTMLAttributes<HTMLSelectElement>;
   readonly getSelectOptionProps: (item: TItem) => DiscretePropertySelectorSelectOptionProps; // React.OptionHTMLAttributes<HTMLOptionElement>;
@@ -56,7 +57,6 @@ export type DiscretePropertySelector<TItem> = {
   readonly getDropdownListItemProps: (item: TItem) => React.LiHTMLAttributes<HTMLLIElement>;
   readonly getRadioItemProps: (item: TItem) => React.HTMLAttributes<HTMLDivElement>;
   readonly getCheckboxDivProps: () => React.HTMLAttributes<HTMLDivElement>;
-  readonly setIsOpen: (toggle: boolean) => void;
 };
 
 export function useDiscretePropertySelector<TItem>(


### PR DESCRIPTION
Fixes #44.

- Exposes useDiscretePropertySelector setIsOpen().
- Tests for setIsOpen().
- Storybook test for setIsOpen().