### PR TITLE
fix(property-selectors)!: removed redundant and faulty isValid check in amount input box debounced onChange

### DIFF
--- a/packages/react-property-selectors/src/__tests__/amount/amount-input-box-test-component.tsx
+++ b/packages/react-property-selectors/src/__tests__/amount/amount-input-box-test-component.tsx
@@ -3,15 +3,18 @@ import { Amount, Unit } from "uom";
 import { getDefaultAmountInputBoxStyle, useAmountInputBox } from "../../amount";
 
 interface State {
-  readonly value: Amount.Amount<unknown>;
+  readonly value: Amount.Amount<unknown> | undefined;
 }
 
 export function AmountInputBoxTestComponent({
   onValueChange,
+  initialValue,
 }: {
   readonly onValueChange: (a: Amount.Amount<unknown>) => void;
+  readonly initialValue: number | undefined;
 }): React.ReactElement<{}> {
-  const value: Amount.Amount<unknown> | undefined = Amount.create(10, Unit.One);
+  const value: Amount.Amount<unknown> | undefined =
+    initialValue !== undefined ? Amount.create(initialValue, Unit.One) : initialValue;
 
   const [state, setState] = useState<State>({
     value,
@@ -43,7 +46,7 @@ export function AmountInputBoxTestComponent({
   return (
     <div>
       <div>AmountInputBox:</div>
-      <div>Value: {Amount.toString(state.value)}</div>
+      <div>Value: {state?.value !== undefined ? Amount.toString(state.value) : "undefined"}</div>
       <input
         data-testid="input"
         type="text"

--- a/packages/react-property-selectors/src/__tests__/amount/amount-input-box.test.tsx
+++ b/packages/react-property-selectors/src/__tests__/amount/amount-input-box.test.tsx
@@ -7,7 +7,7 @@ import { AmountInputBoxTestComponent } from "./amount-input-box-test-component";
 describe("Test <AmountInputBoxTestComponent />", () => {
   it("should call onValueChange after typing a valid value", async () => {
     const onValueChange = jest.fn();
-    render(<AmountInputBoxTestComponent onValueChange={onValueChange} />);
+    render(<AmountInputBoxTestComponent onValueChange={onValueChange} initialValue={10} />);
     const input = screen.getByTestId("input");
     userEvent.type(input, "1");
     expect(input).toHaveValue("101");
@@ -16,18 +16,20 @@ describe("Test <AmountInputBoxTestComponent />", () => {
     await waitFor(() => expect(onValueChange).toHaveBeenCalledWith(a), { timeout: 100 }); // But will get called within 100ms
   });
 
-  it("should not call onValueChange after typing a invalid value", async () => {
+  it("should call onValueChange after changing undefined to a valid value", async () => {
     const onValueChange = jest.fn();
-    render(<AmountInputBoxTestComponent onValueChange={onValueChange} />);
+    render(<AmountInputBoxTestComponent onValueChange={onValueChange} initialValue={undefined} />);
     const input = screen.getByTestId("input");
-    userEvent.type(input, "A");
-    expect(input).toHaveValue("10A");
-    await waitFor(() => expect(onValueChange).not.toHaveBeenCalled(), { timeout: 100 });
+    userEvent.type(input, "1");
+    expect(input).toHaveValue("1");
+    const a = Amount.create(1, Unit.One);
+    expect(onValueChange).not.toHaveBeenCalled(); // It won't be called immediately
+    await waitFor(() => expect(onValueChange).toHaveBeenCalledWith(a), { timeout: 100 });
   });
 
-  it("should not call onValueChange after changing an invalid value back to valid", async () => {
+  it("should call onValueChange after changing an invalid value back to valid", async () => {
     const onValueChange = jest.fn();
-    render(<AmountInputBoxTestComponent onValueChange={onValueChange} />);
+    render(<AmountInputBoxTestComponent onValueChange={onValueChange} initialValue={10} />);
     const input = screen.getByTestId("input");
     userEvent.type(input, "A{backspace}1");
     expect(input).toHaveValue("101");
@@ -36,9 +38,27 @@ describe("Test <AmountInputBoxTestComponent />", () => {
     await waitFor(() => expect(onValueChange).toHaveBeenCalledWith(a), { timeout: 100 });
   });
 
+  it("should not call onValueChange after typing an invalid value", async () => {
+    const onValueChange = jest.fn();
+    render(<AmountInputBoxTestComponent onValueChange={onValueChange} initialValue={10} />);
+    const input = screen.getByTestId("input");
+    userEvent.type(input, "A");
+    expect(input).toHaveValue("10A");
+    await waitFor(() => expect(onValueChange).not.toHaveBeenCalled(), { timeout: 100 });
+  });
+
+  it("should not call onValueChange changing value to empty", async () => {
+    const onValueChange = jest.fn();
+    render(<AmountInputBoxTestComponent onValueChange={onValueChange} initialValue={1} />);
+    const input = screen.getByTestId("input");
+    userEvent.type(input, "{backspace}");
+    expect(input).toHaveValue("");
+    await waitFor(() => expect(onValueChange).not.toHaveBeenCalled(), { timeout: 100 });
+  });
+
   it("should work to make quick changes including invalid 'values'", async () => {
     const onValueChange = jest.fn();
-    render(<AmountInputBoxTestComponent onValueChange={onValueChange} />);
+    render(<AmountInputBoxTestComponent onValueChange={onValueChange} initialValue={10} />);
     const input = screen.getByTestId("input");
     userEvent.clear(input);
     userEvent.type(input, "10");

--- a/packages/react-property-selectors/src/amount/use-amount-input-box.tsx
+++ b/packages/react-property-selectors/src/amount/use-amount-input-box.tsx
@@ -70,7 +70,7 @@ export function useAmountInputBox(options: UseAmountInputBoxOptions): UseAmountI
       // but we still received the delayed event from when the input was valid. Therefore
       // we need an extra check here to make sure that the current input is valid before we
       // dispatch the value change.
-      if (state.isValid && newAmount) {
+      if (newAmount) {
         onValueChange(newAmount);
       }
     }, debounceTime),


### PR DESCRIPTION
state.isValid is the result of the previous value of the input box. To me it seems like newAmount !== undefined should be enough to check if the value is valid? 