### PR TITLE
Fix invalid integer parsing

### DIFF
--- a/packages/property/src/__tests__/property-value-set.test.ts
+++ b/packages/property/src/__tests__/property-value-set.test.ts
@@ -41,6 +41,15 @@ describe("PropertyValueSet", () => {
       expect(PropertyValueSet.get("a", pvs)).toEqual(PropertyValue.fromInteger(1));
       expect(PropertyValueSet.get("b", pvs)).toEqual(PropertyValue.fromInteger(2));
     });
+
+    it("should not parse a=1;b={invalidinteger};", () => {
+      try {
+        PropertyValueSet.fromString("a=1;b={invalidinteger}", unitLookup);
+        expect(true).toBe(false);
+      } catch (e) {
+        expect(e.message).toBe("a=1;b={invalidinteger} is not a valid PropertyValueSet");
+      }
+    });
   });
 
   describe("set", () => {

--- a/packages/property/src/__tests__/property-value.test.ts
+++ b/packages/property/src/__tests__/property-value.test.ts
@@ -15,6 +15,9 @@ describe("PropertyValue", () => {
     const pv1 = fromStringOrException("2");
     expect(PropertyValue.getInteger(pv1)).toBe(2);
   });
+  it("should_not_parse_invalid_integer", () => {
+    expect(() => fromStringOrException("{invalidinteger}")).toThrowError();
+  });
 
   it("should_parse_text", () => {
     const pv1 = fromStringOrException('"Olle"');

--- a/packages/property/src/__tests__/property-value.test.ts
+++ b/packages/property/src/__tests__/property-value.test.ts
@@ -15,8 +15,10 @@ describe("PropertyValue", () => {
     const pv1 = fromStringOrException("2");
     expect(PropertyValue.getInteger(pv1)).toBe(2);
   });
+
   it("should_not_parse_invalid_integer", () => {
-    expect(() => fromStringOrException("{invalidinteger}")).toThrowError();
+    const pv1 = PropertyValue.fromString("{invalidinteger}", unitLookup);
+    expect(pv1).toBe(undefined);
   });
 
   it("should_parse_text", () => {

--- a/packages/property/src/property-value.ts
+++ b/packages/property/src/property-value.ts
@@ -49,7 +49,7 @@ export function create(type: PropertyType, value: Amount.Amount<unknown> | strin
 
 export function fromString(encodedValue: string, unitLookup: UnitMap.UnitLookup): PropertyValue | undefined {
   const result = _fromSerializedStringOrUndefinedIfInvalidString(encodedValue, unitLookup);
-  if (result === null) {
+  if (result === undefined) {
     console.warn(`PropertyValue.fromString(): Could not parse encoded value: '${encodedValue}'`);
   }
   return result;
@@ -269,7 +269,7 @@ function _fromSerializedStringOrUndefinedIfInvalidString(
     }
   } else {
     const integerValue: number = parseInt(encodedValue, 10);
-    if (integerValue === null) {
+    if (!Number.isInteger(integerValue)) {
       return undefined;
     }
     deserializedValue = fromInteger(integerValue);


### PR DESCRIPTION
When parsing a string as PropertyValue it was returned as `NaN`. This indicated that the parse was successful. Instead we should return `undefined` to indicate that the parse was unsuccessful.