### PR TITLE
More relaxed rules for string values

### DIFF
--- a/packages/property/src/__tests__/data/property-filter-is-syntax-valid.ts
+++ b/packages/property/src/__tests__/data/property-filter-is-syntax-valid.ts
@@ -130,6 +130,16 @@ export const tests = [
     result: false,
   },
   {
+    name: "should_accept_underscore_in_property_name",
+    f: "prop_a=2",
+    result: true,
+  },
+  {
+    name: "should_accept_underscore_in_string_value",
+    f: 'a="m3_h"',
+    result: true,
+  },
+  {
     name: "amount_value_is_supported",
     f: "a>=20:Kelvin&b=20:Meter~30:Meter",
     result: true,

--- a/packages/property/src/property-filter-ast/pegjs/generated-parser.js
+++ b/packages/property/src/property-filter-ast/pegjs/generated-parser.js
@@ -39,8 +39,8 @@ module.exports = (function () {
       peg$c1 = { type: "class", value: "[a-z]i", description: "[a-z]i" },
       peg$c2 = /^[0-9]/,
       peg$c3 = { type: "class", value: "[0-9]", description: "[0-9]" },
-      peg$c4 = /^[a-z0-9 ]/i,
-      peg$c5 = { type: "class", value: "[a-z0-9 ]i", description: "[a-z0-9 ]i" },
+      peg$c4 = /^[^\0-\x1F"\\]/,
+      peg$c5 = { type: "class", value: "[^\\0-\\x1F\\x22\\x5C]", description: "[^\\0-\\x1F\\x22\\x5C]" },
       peg$c6 = ".",
       peg$c7 = { type: "literal", value: ".", description: '"."' },
       peg$c8 = "_",
@@ -387,7 +387,7 @@ module.exports = (function () {
       return s0;
     }
 
-    function peg$parseany() {
+    function peg$parseunescaped() {
       var s0;
 
       if (peg$c4.test(input.charAt(peg$currPos))) {
@@ -488,10 +488,10 @@ module.exports = (function () {
       }
       if (s2 !== peg$FAILED) {
         s3 = [];
-        s4 = peg$parseany();
+        s4 = peg$parseunescaped();
         while (s4 !== peg$FAILED) {
           s3.push(s4);
-          s4 = peg$parseany();
+          s4 = peg$parseunescaped();
         }
         if (s3 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 34) {

--- a/packages/property/src/property-filter-ast/pegjs/parser.pegjs
+++ b/packages/property/src/property-filter-ast/pegjs/parser.pegjs
@@ -35,8 +35,8 @@ letter
   = [a-z]i
 digit
 	 = [0-9]
-any
-	= [a-z0-9 ]i
+unescaped
+  = [^\0-\x1F\x22\x5C]
 identletter
   = letter / "." / "_"
 
@@ -45,7 +45,7 @@ identletter
 ident
   = $(identletter (identletter / digit)*)
 propval
-  = $('"' any* '"')
+  = $('"' unescaped* '"')
   / $("-"? digit+ ("." digit+)? (":" letter+)?)
 
 // optional whitespace


### PR DESCRIPTION
Allow more characters for string values (within quotation marks).
The unescaped rule comes from here:
https://github.com/pegjs/pegjs/blob/master/examples/json.pegjs#L143
It includes all printable characters from the ASCII-table except double quotes and backslash (x22  = `"`  x5C =  `\`).